### PR TITLE
[RFR] Fixed Serialization of AbstractEntity

### DIFF
--- a/src/SensioLabs/Connect/Api/Entity/AbstractEntity.php
+++ b/src/SensioLabs/Connect/Api/Entity/AbstractEntity.php
@@ -19,7 +19,7 @@ use SensioLabs\Connect\Api\Model\Form;
  *
  * @author Marc Weistroff <marc.weistroff@sensiolabs.com>
  */
-abstract class AbstractEntity implements \ArrayAccess
+abstract class AbstractEntity implements \ArrayAccess, \Serializable
 {
     private $selfUrl;
     private $alternateUrl;
@@ -218,6 +218,17 @@ abstract class AbstractEntity implements \ArrayAccess
     public function getSelfUrl()
     {
         return $this->selfUrl;
+    }
+
+    public function serialize()
+    {
+        return serialize(array($this->selfUrl, $this->alternateUrl, $this->properties));
+    }
+
+    public function unserialize($str)
+    {
+        list($this->selfUrl, $this->alternateUrl, $this->properties) = unserialize($str);
+        $this->forms = array();
     }
 
     abstract protected function configure();


### PR DESCRIPTION
Currently the serialisation of `ConnectToken` trigger the serialisation of `ApiUser`.
However the serialisation of `ApiUser` is naive and nothing in particular is done.
This leads to a really big string (~500 Kb in my case) and can lead to potential break (in my case only in production :/) because of the serialisation of `SensioLabs\Connect\Api\Api`.
Moreover there is no advantage of serialising it as it's not usable afterwards (see #15).
