### PR TITLE
Nullable arguments in OAuthException constructor

### DIFF
--- a/src/Exception/OAuthException.php
+++ b/src/Exception/OAuthException.php
@@ -18,7 +18,7 @@ class OAuthException extends \RuntimeException implements ExceptionInterface
 {
     private $type;
 
-    public function __construct(string $type, string $message, \Throwable $previousException = null)
+    public function __construct(string $type = null, string $message = null, \Throwable $previousException = null)
     {
         $this->type = $type ?: 'unknow type';
 


### PR DESCRIPTION
This change will fix an issue: in src/Security/Firewall/ConnectAuthenticationListener.php at line 65, we create an OAuthException with $request->query->get('error_description') as a second argument. But this can be bull in the $request query doesn't carry any error_description parameter.