### PR TITLE
Fix compatibility with SecurityBundle 5.2

### DIFF
--- a/src/DependencyInjection/Security/Factory/AuthenticatorConnectFactory.php
+++ b/src/DependencyInjection/Security/Factory/AuthenticatorConnectFactory.php
@@ -13,6 +13,12 @@ namespace SymfonyCorp\Connect\DependencyInjection\Security\Factory;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 
-class AuthenticatorConnectFactory extends ConnectFactory implements AuthenticatorFactoryInterface
-{
+if (interface_exists(EntryPointFactoryInterface::class)) {
+    class AuthenticatorConnectFactory extends ConnectFactory implements AuthenticatorFactoryInterface, EntryPointFactoryInterface
+    {
+    }
+} else {
+    class AuthenticatorConnectFactory extends ConnectFactory implements AuthenticatorFactoryInterface
+    {
+    }
 }


### PR DESCRIPTION
The `EntryPointFactoryInterface` interface has been removed in 5.2 (https://github.com/symfony/symfony/pull/39153)

from SY'mfony's changelog

>  * [BC break] Removed `EntryPointFactoryInterface`, authenticators must now implement `AuthenticationEntryPointInterface` if they require autoregistration of a Security entry point.

The ConnectAuthenticator already implements the `AuthenticationEntryPointInterface` interface, so I think this patch should be enough, but I'm not sure. @wouterj could you please have a look?