### PR TITLE
Renamed providerKey to firewallName

### DIFF
--- a/src/Resources/config/security.xml
+++ b/src/Resources/config/security.xml
@@ -22,7 +22,7 @@
 
        <service id="security.authentication.provider.symfony_connect" class="SymfonyCorp\Connect\Security\Authentication\Provider\ConnectAuthenticationProvider" abstract="true">
            <argument /> <!-- user provider -->
-           <argument /> <!-- providerKey -->
+           <argument /> <!-- firewallName / providerKey -->
        </service>
 
         <service id="security.authentication.entry_point.symfony_connect" class="SymfonyCorp\Connect\Security\EntryPoint\ConnectEntryPoint">

--- a/src/Security/Authentication/Provider/ConnectAuthenticationProvider.php
+++ b/src/Security/Authentication/Provider/ConnectAuthenticationProvider.php
@@ -23,12 +23,12 @@ use SymfonyCorp\Connect\Security\Authentication\Token\ConnectToken;
 class ConnectAuthenticationProvider implements AuthenticationProviderInterface
 {
     private $userProvider;
-    private $providerKey;
+    private $firewallName;
 
-    public function __construct(UserProviderInterface $userProvider, $providerKey)
+    public function __construct(UserProviderInterface $userProvider, $firewallName)
     {
         $this->userProvider = $userProvider;
-        $this->providerKey = $providerKey;
+        $this->firewallName = $firewallName;
     }
 
     public function authenticate(TokenInterface $token): TokenInterface
@@ -36,7 +36,7 @@ class ConnectAuthenticationProvider implements AuthenticationProviderInterface
         try {
             $localUser = $this->userProvider->loadUserByUsername($token->getUser());
 
-            $authorizedToken = new ConnectToken($localUser, $token->getAccessToken(), $token->getApiUser(), $this->providerKey, $token->getScope(), $localUser->getRoles());
+            $authorizedToken = new ConnectToken($localUser, $token->getAccessToken(), $token->getApiUser(), $this->firewallName, $token->getScope(), $localUser->getRoles());
             $authorizedToken->setAttributes($token->getAttributes());
 
             return $authorizedToken;

--- a/src/Security/Authentication/Token/ConnectToken.php
+++ b/src/Security/Authentication/Token/ConnectToken.php
@@ -23,22 +23,22 @@ use SymfonyCorp\Connect\Api\Entity\User;
 class ConnectToken extends AbstractToken
 {
     private $accessToken;
-    private $providerKey;
+    private $firewallName;
     private $apiUser;
     private $scope;
 
-    public function __construct($user, $accessToken, User $apiUser = null, $providerKey, $scope = null, array $roles = [])
+    public function __construct($user, $accessToken, User $apiUser = null, $firewallName, $scope = null, array $roles = [])
     {
         parent::__construct($roles);
 
-        if (empty($providerKey)) {
-            throw new \InvalidArgumentException('$providerKey must not be empty.');
+        if (empty($firewallName)) {
+            throw new \InvalidArgumentException('$firewallName must not be empty.');
         }
 
         $this->setUser($user);
         $this->setAccessToken($accessToken);
         $this->apiUser = $apiUser;
-        $this->providerKey = $providerKey;
+        $this->firewallName = $firewallName;
         $this->scope = $scope;
 
         parent::setAuthenticated(\count($roles) > 0);
@@ -98,9 +98,17 @@ class ConnectToken extends AbstractToken
         return $this->apiUser;
     }
 
+    /**
+     * @deprecated use getFirewallName() instead
+     */
     public function getProviderKey()
     {
-        return $this->providerKey;
+        return $this->firewallName;
+    }
+
+    public function getFirewallName()
+    {
+        return $this->firewallName;
     }
 
     public function getCredentials()
@@ -110,12 +118,12 @@ class ConnectToken extends AbstractToken
 
     public function __serialize(): array
     {
-        return [$this->apiUser, $this->accessToken, $this->providerKey, $this->scope, parent::__serialize()];
+        return [$this->apiUser, $this->accessToken, $this->firewallName, $this->scope, parent::__serialize()];
     }
 
     public function __unserialize(array $data): void
     {
-        list($this->apiUser, $this->accessToken, $this->providerKey, $this->scope, $parentState) = $data;
+        list($this->apiUser, $this->accessToken, $this->firewallName, $this->scope, $parentState) = $data;
 
         parent::__unserialize($parentState);
     }


### PR DESCRIPTION
While upgrading a Symfony app to 5.3, I saw this error:

```
1x: Since symfony/security-http 5.2:
Method "SymfonyCorp\Connect\Security\Authentication\Token\ConnectToken::getProviderKey()"
has been deprecated, rename it to "getFirewallName()" instead.
```

I've added that method, and renamed all private properties to `$firewallName`. There's still a `$this->providerKey` usage because I think we can't update that (the class extends from a Symfony class and gets the property from there).

Please note that I don't know if all this is correct and/or enough. Thanks!