### PR TITLE
Fix a deprecation in getAlias() method of DI extension

### DIFF
--- a/src/DependencyInjection/SymfonyConnectExtension.php
+++ b/src/DependencyInjection/SymfonyConnectExtension.php
@@ -28,6 +28,9 @@ class SymfonyConnectExtension extends Extension
         $this->securityEnabled = true;
     }
 
+    /**
+     * @return string
+     */
     public function getAlias()
     {
         return 'symfony_connect';


### PR DESCRIPTION
Fixes this deprecation:

>   1x: Method "Symfony\Component\DependencyInjection\Extension\Extension::getAlias()"
> might add "string" as a native return type declaration in the future.
>
> Do the same in child class "SymfonyCorp\Connect\DependencyInjection\SymfonyConnectExtension"
> now to avoid errors or add an explicit @return annotation to suppress this message.