### PR TITLE
Fix the setAuthenticated() usage deprecation

### DIFF
--- a/src/Security/Authentication/Token/ConnectToken.php
+++ b/src/Security/Authentication/Token/ConnectToken.php
@@ -41,7 +41,10 @@ class ConnectToken extends AbstractToken
         $this->firewallName = $firewallName;
         $this->scope = $scope;
 
-        parent::setAuthenticated(\count($roles) > 0);
+        // @deprecated since Symfony 5.4
+        if (method_exists($this, 'setAuthenticated')) {
+            parent::setAuthenticated(\count($roles) > 0, false);
+        }
     }
 
     public function getRoleNames(): array


### PR DESCRIPTION
I took inspiration from the following Symfony code but I don't know if this is the best possible solution:

https://github.com/symfony/symfony/blob/a14eb3f782ed01151f88ff4c61eb286a347b4746/src/Symfony/Bundle/FrameworkBundle/KernelBrowser.php#L123-L126