### PR TITLE
Fix bundle deprecation

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,7 +19,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('symfony_connect');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/DependencyInjection/Security/Factory/AuthenticatorConnectFactory.php
+++ b/src/DependencyInjection/Security/Factory/AuthenticatorConnectFactory.php
@@ -16,9 +16,17 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\Authentic
 if (interface_exists(EntryPointFactoryInterface::class)) {
     class AuthenticatorConnectFactory extends ConnectFactory implements AuthenticatorFactoryInterface, EntryPointFactoryInterface
     {
+        public function getPriority(): int
+        {
+            return 0;
+        }
     }
 } else {
     class AuthenticatorConnectFactory extends ConnectFactory implements AuthenticatorFactoryInterface
     {
+        public function getPriority(): int
+        {
+            return 0;
+        }
     }
 }

--- a/src/DependencyInjection/Security/Factory/ConnectFactory.php
+++ b/src/DependencyInjection/Security/Factory/ConnectFactory.php
@@ -74,20 +74,17 @@ class ConnectFactory extends AbstractFactory
         return 'security.authentication.listener.symfony_connect';
     }
 
-    public function getPosition()
+    public function getPosition(): string
     {
         return 'form';
     }
 
-    public function getKey()
+    public function getKey(): string
     {
         return 'symfony_connect';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function createEntryPoint($container, $id, $config, $defaultEntryPointId)
+    protected function createEntryPoint($container, $id, $config, $defaultEntryPointId): ?string
     {
         $entryPoint = 'security.authentication.entry_point.symfony_connect.'.$id;
         $container

--- a/src/SymfonyConnectBundle.php
+++ b/src/SymfonyConnectBundle.php
@@ -13,6 +13,7 @@ namespace SymfonyCorp\Connect;
 
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use SymfonyCorp\Connect\DependencyInjection\Security\Factory\AuthenticatorConnectFactory;
 use SymfonyCorp\Connect\DependencyInjection\Security\Factory\ConnectFactory;
@@ -24,7 +25,7 @@ use SymfonyCorp\Connect\DependencyInjection\SymfonyConnectExtension;
  */
 class SymfonyConnectBundle extends Bundle
 {
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         if (null === $this->extension) {
             $this->extension = new SymfonyConnectExtension();


### PR DESCRIPTION
Fixes these deprecations:

Method "Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension()" 
might add "?ExtensionInterface" as a native return type declaration in the future.
Do the same in child class "SymfonyCorp\Connect\SymfonyConnectBundle"

Method "Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface::getPosition()"
might add "string" as a native return type declaration in the future.
Do the same in implementation "SymfonyCorp\Connect\DependencyInjection\Security\Factory\ConnectFactory"

Method "Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface::getKey()"
might add "string" as a native return type declaration in the future.
Do the same in implementation "SymfonyCorp\Connect\DependencyInjection\Security\Factory\ConnectFactory"

Method "Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory::createEntryPoint()"
might add "?string" as a native return type declaration in the future.
Do the same in child class "SymfonyCorp\Connect\DependencyInjection\Security\Factory\ConnectFactory"

Class "SymfonyCorp\Connect\DependencyInjection\Security\Factory\AuthenticatorConnectFactory"
should implement method "Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface::getPriority(): int": 
defines the position at which the authenticator is called.

Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()"
might add "TreeBuilder" as a native return type declaration in the future.
Do the same in implementation "SymfonyCorp\Connect\DependencyInjection\Configuration"
