### PR TITLE
Fix more deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 7.2
-    - php: 7.4
     - php: 8.0
     - php: 8.0
       env: deps=low

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,12 @@
         "php": ">=8.0.2",
         "ext-dom": "*",
         "ext-json": "*",
-        "psr/log": "^1.0",
-        "symfony/http-client": "^4.4|^5.0|^6.0"
+        "symfony/http-client": "^5.4|^6.0"
     },
     "require-dev": {
-        "symfony/form": "^4.4|^5.0|^6.0",
-        "symfony/security-bundle": "^5.2|^6.0",
-        "symfony/phpunit-bridge": "^4.4|^5.0|^6.0"
+        "symfony/form": "^5.4|^6.0",
+        "symfony/security-bundle": "^5.4|^6.0",
+        "symfony/phpunit-bridge": "^5.4|^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -30,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "7.x-dev"
+            "dev-master": "8.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -7,16 +7,16 @@
     "license": "MIT",
     "authors": [],
     "require": {
-        "php": ">=7.2.4",
+        "php": ">=8.0.2",
         "ext-dom": "*",
         "ext-json": "*",
         "psr/log": "^1.0",
-        "symfony/http-client": "^4.4|^5.0"
+        "symfony/http-client": "^4.4|^5.0|^6.0"
     },
     "require-dev": {
-        "symfony/form": "^4.4|^5.0",
-        "symfony/security-bundle": "^5.2",
-        "symfony/phpunit-bridge": "^4.4|^5.0"
+        "symfony/form": "^4.4|^5.0|^6.0",
+        "symfony/security-bundle": "^5.2|^6.0",
+        "symfony/phpunit-bridge": "^4.4|^5.0|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -151,7 +151,7 @@ class Api
         }
 
         $parts = parse_url($url);
-        $parts['query'] = $parts['query'] ?? null;
+        $parts['query'] = $parts['query'] ?? '';
         parse_str($parts['query'], $query);
         $query['access_token'] = $this->getAccessToken();
         $parts['query'] = http_build_query($query);

--- a/src/Api/Entity/AbstractEntity.php
+++ b/src/Api/Entity/AbstractEntity.php
@@ -205,34 +205,22 @@ abstract class AbstractEntity implements \ArrayAccess, \Serializable
         $this->properties[$property][] = $value;
     }
 
-    /**
-     * @return bool
-     */
-    public function offsetExists($index)
+    public function offsetExists(mixed $index): bool
     {
         return \array_key_exists($index, $this->properties);
     }
 
-    /**
-     * @return mixed
-     */
-    public function offsetGet($index)
+    public function offsetGet(mixed $index): mixed
     {
         return $this->get($index);
     }
 
-    /**
-     * @return void
-     */
-    public function offsetSet($index, $value)
+    public function offsetSet(mixed $index, mixed $value): void
     {
         $this->set($index, $value);
     }
 
-    /**
-     * @return void
-     */
-    public function offsetUnset($index)
+    public function offsetUnset(mixed $index): void
     {
         throw new \BadMethodCallException('Not available.');
     }
@@ -247,14 +235,14 @@ abstract class AbstractEntity implements \ArrayAccess, \Serializable
         return $this->selfUrl;
     }
 
-    public function serialize()
+    public function __serialize(): array
     {
-        return serialize([$this->selfUrl, $this->alternateUrl, $this->properties]);
+        return [$this->selfUrl, $this->alternateUrl, $this->properties];
     }
 
-    public function unserialize($str)
+    public function __unserialize(array $data): void
     {
-        list($this->selfUrl, $this->alternateUrl, $this->properties) = unserialize($str);
+        [$this->selfUrl, $this->alternateUrl, $this->properties] = $data;
         $this->forms = [];
     }
 

--- a/src/Api/Entity/AbstractEntity.php
+++ b/src/Api/Entity/AbstractEntity.php
@@ -246,5 +246,16 @@ abstract class AbstractEntity implements \ArrayAccess, \Serializable
         $this->forms = [];
     }
 
+    public function serialize(): string
+    {
+        return serialize([$this->selfUrl, $this->alternateUrl, $this->properties]);
+    }
+
+    public function unserialize(string $data): void
+    {
+        [$this->selfUrl, $this->alternateUrl, $this->properties] = unserialize($data);
+        $this->forms = [];
+    }
+
     abstract protected function configure();
 }

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -23,7 +23,7 @@ class ApiException extends \RuntimeException implements ExceptionInterface
         $this->body = $body;
         $this->headers = [];
 
-        parent::__construct($message, $code, $previous);
+        parent::__construct($message ?? '', $code, $previous);
     }
 
     public function getStatusCode()

--- a/src/Security/Authentication/Token/ConnectToken.php
+++ b/src/Security/Authentication/Token/ConnectToken.php
@@ -12,7 +12,6 @@
 namespace SymfonyCorp\Connect\Security\Authentication\Token;
 
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
-use Symfony\Component\Security\Core\Role\Role;
 use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use SymfonyCorp\Connect\Api\Entity\User;
@@ -147,8 +146,8 @@ class ConnectToken extends AbstractToken
 
     private function getStringUserRole($role)
     {
-        if (!\is_string($role) && !($role instanceof Role)) {
-            throw new \InvalidArgumentException(sprintf('$roles must be an array of strings, or Role instances, but got %s.', \gettype($role)));
+        if (!\is_string($role)) {
+            throw new \InvalidArgumentException(sprintf('$roles must be an array of strings, but got %s.', \gettype($role)));
         }
 
         return (string) $role;
@@ -156,14 +155,6 @@ class ConnectToken extends AbstractToken
 
     private function getObjectUserRole($role)
     {
-        if (\is_string($role)) {
-            return new Role($role);
-        }
-
-        if (!$role instanceof RoleInterface) {
-            throw new \InvalidArgumentException(sprintf('$roles must be an array of strings, or RoleInterface instances, but got %s.', \gettype($role)));
-        }
-
-        return $role;
+        return (string) $role;
     }
 }

--- a/src/Security/Authentication/Token/ConnectToken.php
+++ b/src/Security/Authentication/Token/ConnectToken.php
@@ -50,24 +50,10 @@ class ConnectToken extends AbstractToken
     {
         $user = $this->getUser();
         if ($user instanceof UserInterface) {
-            return $this->getUserRoles($user);
+            return $user->getRoles();
         }
 
         return parent::getRoleNames();
-    }
-
-    public function getRoles()
-    {
-        $user = $this->getUser();
-        if ($user instanceof UserInterface) {
-            return $this->getUserRoles($user);
-        }
-
-        if (method_exists(AbstractToken::class, 'getRoleNames')) {
-            return parent::getRoleNames();
-        }
-
-        return parent::getRoles();
     }
 
     public function setScope($scope)
@@ -100,23 +86,15 @@ class ConnectToken extends AbstractToken
         return $this->apiUser;
     }
 
-    /**
-     * @deprecated use getFirewallName() instead
-     */
-    public function getProviderKey()
-    {
-        return $this->firewallName;
-    }
-
     public function getFirewallName()
     {
         return $this->firewallName;
     }
 
     /**
-     * @return mixed
+     * @deprecated since Symfony 5.4
      */
-    public function getCredentials()
+    public function getCredentials(): mixed
     {
         return $this->accessToken;
     }
@@ -131,30 +109,5 @@ class ConnectToken extends AbstractToken
         list($this->apiUser, $this->accessToken, $this->firewallName, $this->scope, $parentState) = $data;
 
         parent::__unserialize($parentState);
-    }
-
-    private function getUserRoles(UserInterface $user)
-    {
-        $callBackMethod = 'getObjectUserRole';
-
-        if (method_exists(AbstractToken::class, 'getRoleNames')) {
-            $callBackMethod = 'getStringUserRole';
-        }
-
-        return array_map([$this, $callBackMethod], $user->getRoles());
-    }
-
-    private function getStringUserRole($role)
-    {
-        if (!\is_string($role)) {
-            throw new \InvalidArgumentException(sprintf('$roles must be an array of strings, but got %s.', \gettype($role)));
-        }
-
-        return (string) $role;
-    }
-
-    private function getObjectUserRole($role)
-    {
-        return (string) $role;
     }
 }

--- a/src/Security/EventListener/LoginSuccessEventListener.php
+++ b/src/Security/EventListener/LoginSuccessEventListener.php
@@ -39,7 +39,7 @@ class LoginSuccessEventListener implements EventSubscriberInterface
         $this->em->flush();
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             LoginSuccessEvent::class => 'onLoginSuccess',

--- a/src/SymfonyConnectBundle.php
+++ b/src/SymfonyConnectBundle.php
@@ -45,7 +45,13 @@ class SymfonyConnectBundle extends Bundle
             } else {
                 $securityFactory = new ConnectFactory();
             }
-            $container->getExtension('security')->addSecurityListenerFactory($securityFactory);
+
+            if (method_exists($container->getExtension('security'), 'addAuthenticatorFactory')) {
+                $container->getExtension('security')->addAuthenticatorFactory($securityFactory);
+            } else {
+                // deprecated since Symfony 5.4
+                $container->getExtension('security')->addSecurityListenerFactory($securityFactory);
+            }
         }
     }
 }

--- a/src/SymfonyConnectBundle.php
+++ b/src/SymfonyConnectBundle.php
@@ -46,12 +46,7 @@ class SymfonyConnectBundle extends Bundle
                 $securityFactory = new ConnectFactory();
             }
 
-            if (method_exists($container->getExtension('security'), 'addAuthenticatorFactory')) {
-                $container->getExtension('security')->addAuthenticatorFactory($securityFactory);
-            } else {
-                // deprecated since Symfony 5.4
-                $container->getExtension('security')->addSecurityListenerFactory($securityFactory);
-            }
+            $container->getExtension('security')->addAuthenticatorFactory($securityFactory);
         }
     }
 }

--- a/tests/Security/Authentication/Token/ConnectTokenTest.php
+++ b/tests/Security/Authentication/Token/ConnectTokenTest.php
@@ -24,7 +24,7 @@ class ConnectTokenTest extends TestCase
     {
         $user = new InMemoryUser('paul', 'xxxx', ['ROLE_SINGLE']);
         $token = new ConnectToken($user, 'xxxx', null, 'xxxx', null, ['ROLE_USER', 'ROLE_ADMIN']);
-        $roles = $token->getRoles();
+        $roles = $token->getRoleNames();
 
         $this->assertCount(1, $roles);
         $this->assertEquals('ROLE_SINGLE', \is_string($roles[0]) ? $roles[0] : $roles[0]->getRole());
@@ -37,6 +37,6 @@ class ConnectTokenTest extends TestCase
         $unserialized = unserialize(serialize($token));
         $this->assertSame($token->getScope(), $unserialized->getScope());
         $this->assertSame($token->getAccessToken(), $unserialized->getAccessToken());
-        $this->assertSame($token->getProviderKey(), $unserialized->getProviderKey());
+        $this->assertSame($token->getFirewallName(), $unserialized->getFirewallName());
     }
 }

--- a/tests/Security/Authentication/Token/ConnectTokenTest.php
+++ b/tests/Security/Authentication/Token/ConnectTokenTest.php
@@ -12,7 +12,7 @@
 namespace SymfonyCorp\Connect\Tests\Security\Authentication\Token;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use SymfonyCorp\Connect\Security\Authentication\Token\ConnectToken;
 
 /**
@@ -20,19 +20,9 @@ use SymfonyCorp\Connect\Security\Authentication\Token\ConnectToken;
  */
 class ConnectTokenTest extends TestCase
 {
-    public function testGetRolesWithStringUser()
-    {
-        $token = new ConnectToken('paul', 'xxxx', null, 'xxxx', null, ['ROLE_USER', 'ROLE_ADMIN']);
-        $roles = $token->getRoles();
-
-        $this->assertCount(2, $roles);
-        $this->assertEquals('ROLE_USER', \is_string($roles[0]) ? $roles[0] : $roles[0]->getRole());
-        $this->assertEquals('ROLE_ADMIN', \is_string($roles[1]) ? $roles[1] : $roles[1]->getRole());
-    }
-
     public function testGetRolesWithUserInterfaceUser()
     {
-        $user = new User('paul', 'xxxx', ['ROLE_SINGLE']);
+        $user = new InMemoryUser('paul', 'xxxx', ['ROLE_SINGLE']);
         $token = new ConnectToken($user, 'xxxx', null, 'xxxx', null, ['ROLE_USER', 'ROLE_ADMIN']);
         $roles = $token->getRoles();
 
@@ -42,7 +32,7 @@ class ConnectTokenTest extends TestCase
 
     public function testSerialization()
     {
-        $user = new User('paul', 'xxxx', ['ROLE_SINGLE']);
+        $user = new InMemoryUser('paul', 'xxxx', ['ROLE_SINGLE']);
         $token = new ConnectToken($user, 'xxxx', null, 'xxxx', null, ['ROLE_USER', 'ROLE_ADMIN']);
         $unserialized = unserialize(serialize($token));
         $this->assertSame($token->getScope(), $unserialized->getScope());


### PR DESCRIPTION
This is the last series of deprecations that I found in this package when upgrading an app to Symfony 5.4:

Since symfony/security-bundle 5.4: Method "Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension::addSecurityListenerFactory()" is deprecated, use "addAuthenticatorFactory()" instead.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "SymfonyCorp\Connect\Security\EventListener\LoginSuccessEventListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Return type of SymfonyCorp\Connect\Api\Entity\AbstractEntity::offsetExists($index) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Return type of SymfonyCorp\Connect\Api\Entity\AbstractEntity::offsetGet($index) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Return type of SymfonyCorp\Connect\Api\Entity\AbstractEntity::offsetSet($index, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

Return type of SymfonyCorp\Connect\Api\Entity\AbstractEntity::offsetUnset($index) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

SymfonyCorp\Connect\Api\Entity\User implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)