### PR TITLE
Fix support for Symfony 6.0

### DIFF
--- a/src/Api/Entity/Index.php
+++ b/src/Api/Entity/Index.php
@@ -36,12 +36,12 @@ class Index extends AbstractEntity implements \Countable, \IteratorAggregate
     protected function configure()
     {
         $this->addProperty('items', [])
-             ->addProperty('total')
-             ->addProperty('count')
-             ->addProperty('index')
-             ->addProperty('limit')
-             ->addProperty('nextUrl')
-             ->addProperty('prevUrl')
+            ->addProperty('total')
+            ->addProperty('count')
+            ->addProperty('index')
+            ->addProperty('limit')
+            ->addProperty('nextUrl')
+            ->addProperty('prevUrl')
         ;
     }
 
@@ -93,19 +93,19 @@ class Index extends AbstractEntity implements \Countable, \IteratorAggregate
         return \array_key_exists($offset, $this->get('items'));
     }
 
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
         $items = $this->get('items');
 
         return $items[$offset];
     }
 
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         throw new \BadMethodCallException('Not implemented.');
     }
 
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         throw new \BadMethodCallException('Not implemented.');
     }

--- a/src/DependencyInjection/Security/Factory/ConnectFactory.php
+++ b/src/DependencyInjection/Security/Factory/ConnectFactory.php
@@ -102,4 +102,9 @@ class ConnectFactory extends AbstractFactory
 
         return new DefinitionDecorator($id);
     }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
 }

--- a/src/DependencyInjection/SymfonyConnectExtension.php
+++ b/src/DependencyInjection/SymfonyConnectExtension.php
@@ -28,10 +28,7 @@ class SymfonyConnectExtension extends Extension
         $this->securityEnabled = true;
     }
 
-    /**
-     * @return string
-     */
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'symfony_connect';
     }

--- a/src/Security/Authentication/Provider/ConnectAuthenticationProvider.php
+++ b/src/Security/Authentication/Provider/ConnectAuthenticationProvider.php
@@ -34,7 +34,7 @@ class ConnectAuthenticationProvider implements AuthenticationProviderInterface
     public function authenticate(TokenInterface $token): TokenInterface
     {
         try {
-            $localUser = $this->userProvider->loadUserByUsername($token->getUser());
+            $localUser = $this->userProvider->loadUserByIdentifier($token->getUser());
 
             $authorizedToken = new ConnectToken($localUser, $token->getAccessToken(), $token->getApiUser(), $this->firewallName, $token->getScope(), $localUser->getRoles());
             $authorizedToken->setAttributes($token->getAttributes());

--- a/src/Security/ConnectAuthenticator.php
+++ b/src/Security/ConnectAuthenticator.php
@@ -135,7 +135,7 @@ class ConnectAuthenticator extends AbstractAuthenticator implements Authenticati
             throw $e;
         }
 
-        $localUser = method_exists($this->userProvider, 'loadUserByUserIdentifier') ? $this->userProvider->loadUserByUserIdentifier($apiUser->getUuid()) : $this->userProvider->loadUserByUsername($apiUser->getUuid());
+        $localUser = method_exists($this->userProvider, 'loadUserByIdentifier') ? $this->userProvider->loadUserByIdentifier($apiUser->getUuid()) : $this->userProvider->loadUserByUsername($apiUser->getUuid());
         if (!$localUser instanceof UserInterface) {
             throw new AuthenticationServiceException('The user provider must return a UserInterface object.');
         }

--- a/src/Security/User/ConnectInMemoryUserProvider.php
+++ b/src/Security/User/ConnectInMemoryUserProvider.php
@@ -12,7 +12,7 @@
 namespace SymfonyCorp\Connect\Security\User;
 
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
-use Symfony\Component\Security\Core\User\User;
+use Symfony\Component\Security\Core\User\InMemoryUser;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 
@@ -31,14 +31,14 @@ class ConnectInMemoryUserProvider implements UserProviderInterface
     public function __construct(array $users = [])
     {
         foreach ($users as $username => $roles) {
-            $this->users[$username] = new User($username, '', (array) $roles, true, true, true, true);
+            $this->users[$username] = new InMemoryUser($username, '', (array) $roles, true);
         }
     }
 
     /**
      * {@inheritdoc}
      */
-    public function loadUserByUsername($username): User
+    public function loadUserByIdentifier($username): UserInterface
     {
         $user = $this->users[$username] ?? new User($username, '', ['ROLE_CONNECT_USER'], true, true, true, true);
 
@@ -48,9 +48,9 @@ class ConnectInMemoryUserProvider implements UserProviderInterface
     /**
      * {@inheritdoc}
      */
-    public function refreshUser(UserInterface $user): User
+    public function refreshUser(UserInterface $user): UserInterface
     {
-        if (!$user instanceof User) {
+        if (!$user instanceof UserInterface) {
             throw new UnsupportedUserException(sprintf('Instances of "%s" are not supported.', \get_class($user)));
         }
 


### PR DESCRIPTION
After the #116 merge, I could test some Symfony 6 apps with it and I found the following errors which are fixed in this PR:

```
Fatal error: Declaration of SymfonyCorp\Connect\DependencyInjection\SymfonyConnectExtension::getAlias()
must be compatible with Symfony\Component\DependencyInjection\Extension\Extension::getAlias(): string
in my-project/vendor/symfonycorp/connect/src/DependencyInjection/SymfonyConnectExtension.php on line 34

PHP Fatal error:  Class SymfonyCorp\Connect\DependencyInjection\Security\Factory\ConnectFactory
contains 1 abstract method and must therefore be declared abstract or implement the remaining methods
(Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface::getPriority)
in my-project/vendor/symfonycorp/connect/src/DependencyInjection/Security/Factory/ConnectFactory.php on line 23

PHP Fatal error:  Could not check compatibility between
SymfonyCorp\Connect\Security\ConnectAuthenticator::authenticate(Symfony\Component\HttpFoundation\Request $request):
    Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface
and Symfony\Component\Security\Http\Authenticator\AuthenticatorInterface::authenticate(Symfony\Component\HttpFoundation\Request $request): 
    Symfony\Component\Security\Http\Authenticator\Passport\Passport,
because class Symfony\Component\Security\Http\Authenticator\Passport\PassportInterface is not available
in my-project/vendor/symfonycorp/connect/src/Security/ConnectAuthenticator.php on line 93

Compile Error: Declaration of SymfonyCorp\Connect\Api\Entity\Index::offsetGet($offset)
must be compatible with SymfonyCorp\Connect\Api\Entity\AbstractEntity::offsetGet(mixed $index): mixed

Fatal error: Declaration of SymfonyCorp\Connect\Api\Entity\Index::offsetSet($offset, $value)
must be compatible with SymfonyCorp\Connect\Api\Entity\AbstractEntity::offsetSet(mixed $index, mixed $value): void
in my-project/vendor/symfonycorp/connect/src/Api/Entity/Index.php on line 103

Fatal error: Declaration of SymfonyCorp\Connect\Api\Entity\Index::offsetUnset($offset)
must be compatible with SymfonyCorp\Connect\Api\Entity\AbstractEntity::offsetUnset(mixed $index): void
in my-project/vendor/symfonycorp/connect/src/Api/Entity/Index.php on line 108
```