### PR TITLE
Fix a method of the Connect authenticator

### DIFF
--- a/src/Security/ConnectAuthenticator.php
+++ b/src/Security/ConnectAuthenticator.php
@@ -153,7 +153,7 @@ class ConnectAuthenticator extends AbstractAuthenticator implements Authenticati
         return $this->httpUtils->checkRequestPath($request, 'symfony_connect_callback');
     }
 
-    public function createAuthenticatedToken(Passport $passport, string $firewallName): TokenInterface
+    public function createToken(Passport $passport, string $firewallName): TokenInterface
     {
         return new ConnectToken($passport->getUser(), $passport->getAttribute('accessToken'), $passport->getAttribute('apiUser'), $firewallName, $passport->getAttribute('scope'), $passport->getUser()->getRoles());
     }


### PR DESCRIPTION
Without this fix, new users can't log in in apps using SymfonyConnect. Only existing users can.

@wouterj was kind enough to debug this problem and found the exact cause of the error 🙇  Thanks a lot Wouter!