### PR TITLE
Fix the declaration of an exception class

### DIFF
--- a/src/Security/Exception/OAuthStrictChecksFailedException.php
+++ b/src/Security/Exception/OAuthStrictChecksFailedException.php
@@ -9,7 +9,7 @@ class OAuthStrictChecksFailedException extends AuthenticationException
         return 'A check failed: %message%';
     }
 
-    public function getMessageData()
+    public function getMessageData(): array
     {
         return [
             '%message%' => $this->getMessage(),


### PR DESCRIPTION
Fixes this error:

```
Compile Error:
Declaration of SymfonyCorp\Connect\Security\Exception\OAuthStrictChecksFailedException::getMessageData()
must be compatible with 
Symfony\Component\Security\Core\Exception\AuthenticationException::getMessageData(): array
```