### PR TITLE
Add some return types to fix deprecations

### DIFF
--- a/src/DependencyInjection/SymfonyConnectExtension.php
+++ b/src/DependencyInjection/SymfonyConnectExtension.php
@@ -33,7 +33,7 @@ class SymfonyConnectExtension extends Extension
         return 'symfony_connect';
     }
 
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $config = $this->processConfiguration(new Configuration(), $configs);
 

--- a/src/SymfonyConnectBundle.php
+++ b/src/SymfonyConnectBundle.php
@@ -34,7 +34,7 @@ class SymfonyConnectBundle extends Bundle
         return $this->extension;
     }
 
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         if ($container->hasExtension('security')) {
             $container->getExtension('symfony_connect')->enableSecurity();


### PR DESCRIPTION
It fixes these two indirect deprecations in my Symfony apps:

* Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future.
* Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future.