### PR TITLE
Fix a PHP deprecation

### DIFF
--- a/src/Api/Entity/Index.php
+++ b/src/Api/Entity/Index.php
@@ -83,7 +83,7 @@ class Index extends AbstractEntity implements \Countable, \IteratorAggregate
         return $this->getCount();
     }
 
-    public function getIterator(): iterable
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($this->get('items'));
     }


### PR DESCRIPTION
It fixes this error:

```
1x: Return type of SymfonyCorp\Connect\Api\Entity\Index::getIterator(): Traversable|array
should either be compatible with IteratorAggregate::getIterator(): Traversable,
or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```