### PR TITLE
Add a return type in a method of AuthenticationException

### DIFF
--- a/src/Security/Exception/AuthenticationException.php
+++ b/src/Security/Exception/AuthenticationException.php
@@ -12,7 +12,7 @@ class AuthenticationException extends BaseAuthenticationException implements Exc
         parent::__construct((string) $previous, 0, $previous);
     }
 
-    public function getMessageKey()
+    public function getMessageKey(): string
     {
         return 'Impossible to process authentication with SymfonyConnect';
     }


### PR DESCRIPTION
I just saw this exception in a Symfony app, and I hope this PR fixes it:

```
Uncaught PHP Exception Symfony\Component\ErrorHandler\Error\FatalError:

Compile Error: Declaration of
SymfonyCorp\Connect\Security\Exception\AuthenticationException::getMessageKey()
must be compatible with 
Symfony\Component\Security\Core\Exception\AuthenticationException::getMessageKey(): string

at AuthenticationException.php line 15
```