### PR TITLE
Fix the usage of some security-related constants

### DIFF
--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -13,7 +13,7 @@ namespace SymfonyCorp\Connect\Controller;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorTrait;
 use SymfonyCorp\Connect\Security\EntryPoint\ConnectEntryPoint;
@@ -51,7 +51,7 @@ class OAuthController
 
     public function failure(Request $request, Environment $twig, TranslatorInterface $translator = null)
     {
-        if (!$e = $request->getSession()->get(Security::AUTHENTICATION_ERROR)) {
+        if (!$e = $request->getSession()->get(SecurityRequestAttributes::AUTHENTICATION_ERROR)) {
             // directly going to this controller without an exception should generate a 404
             return new Response('', 404);
         }

--- a/src/Security/ConnectAuthenticator.php
+++ b/src/Security/ConnectAuthenticator.php
@@ -18,7 +18,6 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\AuthenticationServiceException;
-use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
@@ -28,6 +27,7 @@ use Symfony\Component\Security\Http\Authenticator\Passport\Passport;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
 use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
 use Symfony\Component\Security\Http\HttpUtils;
+use Symfony\Component\Security\Http\SecurityRequestAttributes;
 use SymfonyCorp\Connect\Api\Api;
 use SymfonyCorp\Connect\Exception\ExceptionInterface;
 use SymfonyCorp\Connect\Exception\OAuthException;
@@ -169,7 +169,7 @@ class ConnectAuthenticator extends AbstractAuthenticator implements Authenticati
             return null;
         }
 
-        $request->getSession()->set(Security::AUTHENTICATION_ERROR, $exception);
+        $request->getSession()->set(SecurityRequestAttributes::AUTHENTICATION_ERROR, $exception);
 
         return new RedirectResponse($this->httpUtils->generateUri($request, 'symfony_connect_failure'));
     }


### PR DESCRIPTION
These constants were deprecated in 6.4 and moved in 7.0:

See https://github.com/symfony/symfony/blob/45f1248ec2480f68688fafad12498aa6b05ffded/src/Symfony/Bundle/SecurityBundle/CHANGELOG.md?plain=1#L20