### PR TITLE
Fix usage of a class that was deprecated in Symfony 7.1

### DIFF
--- a/src/DependencyInjection/SymfonyConnectExtension.php
+++ b/src/DependencyInjection/SymfonyConnectExtension.php
@@ -13,8 +13,8 @@ namespace SymfonyCorp\Connect\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * @author Marc Weistroff <marc.weistroff@sensiolabs.com>


### PR DESCRIPTION
Fixes this error spotted while updating apps to Symfony 7.1:

```
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered
internal since Symfony 7.1, to be deprecated in 8.1;
use Symfony\Component\DependencyInjection\Extension\Extension instead.
It may change without further notice. You should not use it from "SymfonyCorp\Connect\DependencyInjection\SymfonyConnectExtension".
```