### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -38,7 +38,7 @@ class Api
     private $endpoint;
     private $accessToken;
 
-    public function __construct(string $endpoint = null, HttpClientInterface $httpClient = null, ParserInterface $parser = null, LoggerInterface $logger = null)
+    public function __construct(?string $endpoint = null, ?HttpClientInterface $httpClient = null, ?ParserInterface $parser = null, ?LoggerInterface $logger = null)
     {
         $this->httpClient = $httpClient ?? HttpClient::create();
         $this->parser = $parser ?? new Parser();

--- a/src/Api/Parser/VndComSymfonyConnectXmlParser.php
+++ b/src/Api/Parser/VndComSymfonyConnectXmlParser.php
@@ -62,7 +62,7 @@ class VndComSymfonyConnectXmlParser implements ParserInterface
         throw new ApiParserException(sprintf('Could not parse this xml document. Is this the right content-type? Body: "%s"', $xml));
     }
 
-    protected function doParse(\DOMElement $element = null)
+    protected function doParse(?\DOMElement $element = null)
     {
         $nodes = $this->xpath->evaluate('./root', $element);
         if (1 === $nodes->length) {
@@ -331,7 +331,7 @@ class VndComSymfonyConnectXmlParser implements ParserInterface
         return $this->getLinkNodeHref('./atom:link[@rel="foaf:depiction"]', $element);
     }
 
-    protected function getNodeValue($query, \DOMElement $element = null, $index = 0)
+    protected function getNodeValue($query, ?\DOMElement $element = null, $index = 0)
     {
         $nodeList = $this->xpath->query($query, $element);
         if ($nodeList->length > 0 && $index <= $nodeList->length) {
@@ -339,7 +339,7 @@ class VndComSymfonyConnectXmlParser implements ParserInterface
         }
     }
 
-    protected function getLinkNodeHref($query, \DOMElement $element = null, $position = 0)
+    protected function getLinkNodeHref($query, ?\DOMElement $element = null, $position = 0)
     {
         $nodeList = $this->xpath->query($query, $element);
 

--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -30,7 +30,7 @@ class OAuthController
     private $startTemplate;
     private $failureTemplate;
 
-    public function __construct(ConnectEntryPoint $entryPoint, string $startTemplate = null, string $failureTemplate = null)
+    public function __construct(ConnectEntryPoint $entryPoint, ?string $startTemplate = null, ?string $failureTemplate = null)
     {
         $this->entryPoint = $entryPoint;
         $this->startTemplate = $startTemplate;
@@ -49,7 +49,7 @@ class OAuthController
         ]));
     }
 
-    public function failure(Request $request, Environment $twig, TranslatorInterface $translator = null)
+    public function failure(Request $request, Environment $twig, ?TranslatorInterface $translator = null)
     {
         if (!$e = $request->getSession()->get(SecurityRequestAttributes::AUTHENTICATION_ERROR)) {
             // directly going to this controller without an exception should generate a 404

--- a/src/OAuthConsumer.php
+++ b/src/OAuthConsumer.php
@@ -38,7 +38,7 @@ class OAuthConsumer
         'authorize' => '/oauth/authorize',
     ];
 
-    public function __construct(string $appId, string $appSecret, string $scope, string $endpoint = null, HttpClientInterface $httpClient = null, LoggerInterface $logger = null)
+    public function __construct(string $appId, string $appSecret, string $scope, ?string $endpoint = null, ?HttpClientInterface $httpClient = null, ?LoggerInterface $logger = null)
     {
         $this->httpClient = $httpClient ?? HttpClient::create();
         $this->appId = $appId;

--- a/src/Security/Authentication/Token/ConnectToken.php
+++ b/src/Security/Authentication/Token/ConnectToken.php
@@ -26,7 +26,7 @@ class ConnectToken extends AbstractToken
     private $apiUser;
     private $scope;
 
-    public function __construct($user, $accessToken, User $apiUser = null, $firewallName, $scope = null, array $roles = [])
+    public function __construct($user, $accessToken, ?User $apiUser = null, $firewallName, ?string $scope = null, array $roles = [])
     {
         parent::__construct($roles);
 

--- a/src/Security/ConnectAuthenticator.php
+++ b/src/Security/ConnectAuthenticator.php
@@ -50,7 +50,7 @@ class ConnectAuthenticator extends AbstractAuthenticator implements Authenticati
     private $startTemplate;
     private $failureTemplate;
 
-    public function __construct(OAuthConsumer $oauthConsumer, Api $api, UserProviderInterface $userProvider, HttpUtils $httpUtils, LoggerInterface $logger = null, string $startTemplate = null, string $failureTemplate = null)
+    public function __construct(OAuthConsumer $oauthConsumer, Api $api, UserProviderInterface $userProvider, HttpUtils $httpUtils, ?LoggerInterface $logger = null, ?string $startTemplate = null, ?string $failureTemplate = null)
     {
         $this->oauthConsumer = $oauthConsumer;
         $this->api = $api;
@@ -66,7 +66,7 @@ class ConnectAuthenticator extends AbstractAuthenticator implements Authenticati
         $this->hideException = !$rethrowException;
     }
 
-    public function start(Request $request, AuthenticationException $authException = null): Response
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         $session = $request->getSession();
         $session->start();

--- a/src/Security/EntryPoint/ConnectEntryPoint.php
+++ b/src/Security/EntryPoint/ConnectEntryPoint.php
@@ -35,7 +35,7 @@ class ConnectEntryPoint implements AuthenticationEntryPointInterface
         $this->oauthCallback = $oauthCallback;
     }
 
-    public function start(Request $request, AuthenticationException $authException = null): Response
+    public function start(Request $request, ?AuthenticationException $authException = null): Response
     {
         $session = $request->getSession();
         $session->start();

--- a/src/Security/EventListener/LoginSuccessEventListener.php
+++ b/src/Security/EventListener/LoginSuccessEventListener.php
@@ -12,7 +12,7 @@ class LoginSuccessEventListener implements EventSubscriberInterface
 {
     private $em;
 
-    public function __construct(EntityManagerInterface $em = null)
+    public function __construct(?EntityManagerInterface $em = null)
     {
         $this->em = $em;
     }


### PR DESCRIPTION
Fixes this:

SymfonyCorp\Connect\Api\Api::__construct(): Implicitly marking parameter $endpoint as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Api\Api::__construct(): Implicitly marking parameter $httpClient as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Api\Api::__construct(): Implicitly marking parameter $parser as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Api\Api::__construct(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Controller\OAuthController::__construct(): Implicitly marking parameter $startTemplate as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Controller\OAuthController::__construct(): Implicitly marking parameter $failureTemplate as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Controller\OAuthController::failure(): Implicitly marking parameter $translator as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Security\ConnectAuthenticator::__construct(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Security\ConnectAuthenticator::__construct(): Implicitly marking parameter $startTemplate as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Security\ConnectAuthenticator::__construct(): Implicitly marking parameter $failureTemplate as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Security\ConnectAuthenticator::start(): Implicitly marking parameter $authException as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\OAuthConsumer::__construct(): Implicitly marking parameter $endpoint as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\OAuthConsumer::__construct(): Implicitly marking parameter $httpClient as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\OAuthConsumer::__construct(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Security\EventListener\LoginSuccessEventListener::__construct(): Implicitly marking parameter $em as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Api\Parser\VndComSymfonyConnectXmlParser::doParse(): Implicitly marking parameter $element as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Api\Parser\VndComSymfonyConnectXmlParser::getNodeValue(): Implicitly marking parameter $element as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Api\Parser\VndComSymfonyConnectXmlParser::getLinkNodeHref(): Implicitly marking parameter $element as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Security\EntryPoint\ConnectEntryPoint::start(): Implicitly marking parameter $authException as nullable is deprecated, the explicit nullable type must be used instead

SymfonyCorp\Connect\Security\Authentication\Token\ConnectToken::__construct(): Implicitly marking parameter $apiUser as nullable is deprecated, the explicit nullable type must be used instead
