### PR TITLE
Fix a nullable issue deprecation

### DIFF
--- a/src/Api/Entity/AbstractEntity.php
+++ b/src/Api/Entity/AbstractEntity.php
@@ -93,7 +93,7 @@ abstract class AbstractEntity implements \ArrayAccess, \Serializable
         return $this->forms;
     }
 
-    public function submit($formId, self $entity = null)
+    public function submit($formId, ?self $entity = null)
     {
         $form = $this->forms[$formId];
         $fields = $form->getFields();


### PR DESCRIPTION
Fixes this:

```
PHP Deprecated:  SymfonyCorp\Connect\Api\Entity\AbstractEntity::submit():
Implicitly marking parameter $entity as nullable is deprecated, the explicit
nullable type must be used instead in
vendor/symfonycorp/connect/src/Api/Entity/AbstractEntity.php on line 96
```