### PR TITLE
Fix a PHP deprecation

### DIFF
--- a/src/Security/Authentication/Token/ConnectToken.php
+++ b/src/Security/Authentication/Token/ConnectToken.php
@@ -26,7 +26,7 @@ class ConnectToken extends AbstractToken
     private $apiUser;
     private $scope;
 
-    public function __construct($user, $accessToken, ?User $apiUser = null, $firewallName, ?string $scope = null, array $roles = [])
+    public function __construct($user, $accessToken, ?User $apiUser, $firewallName, ?string $scope = null, array $roles = [])
     {
         parent::__construct($roles);
 


### PR DESCRIPTION
Fixes this issue:

1) vendor/symfonycorp/connect/src/Security/Authentication/Token/ConnectToken.php:29
SymfonyCorp\Connect\Security\Authentication\Token\ConnectToken::__construct(): Optional parameter $apiUser declared before required parameter $firewallName is implicitly treated as a required parameter