### PR TITLE
Fix routing and update config

### DIFF
--- a/src/Resources/config/connect.php
+++ b/src/Resources/config/connect.php
@@ -11,25 +11,21 @@ use SymfonyCorp\Connect\OAuthConsumer;
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('symfony_connect.oauth_consumer')
-        ->class(OAuthConsumer::class)
-        ->arg(0, '')
-        ->arg(1, '')
-        ->arg(2, '')
-        ->arg(3, null)
+    $services->set('symfony_connect.oauth_consumer', OAuthConsumer::class)
+        ->arg(0, abstract_arg('app id'))
+        ->arg(1, abstract_arg('app secret'))
+        ->arg(2, abstract_arg('app scope'))
+        ->arg(3, abstract_arg('oauth endpoint'))
         ->arg(4, service(HttpClientInterface::class))
         ->arg(5, service('logger')->nullOnInvalid())
         ->tag('monolog.logger', ['channel' => 'symfony_connect']);
 
-    $services->set('symfony_connect.api.parser')
-        ->class(VndComSymfonyConnectXmlParser::class);
+    $services->set('symfony_connect.api.parser', VndComSymfonyConnectXmlParser::class);
 
-    $services->set('symfony_connect.error_translator')
-        ->class(ErrorTranslator::class);
+    $services->set('symfony_connect.error_translator', ErrorTranslator::class);
 
-    $services->set('symfony_connect.api')
-        ->class(Api::class)
-        ->arg(0, '')
+    $services->set('symfony_connect.api', Api::class)
+        ->arg(0, abstract_arg('API endpoint'))
         ->arg(1, service(HttpClientInterface::class))
         ->arg(2, service('symfony_connect.api.parser'))
         ->arg(3, service('logger'))

--- a/src/Resources/config/routing/connect.php
+++ b/src/Resources/config/routing/connect.php
@@ -14,7 +14,7 @@ return static function (RoutingConfigurator $routes): void {
         ->methods(['GET'])
         ->controller([OAuthController::class, 'start']);
 
-    $routes->add('symfony_connect_start', '/failure')
+    $routes->add('symfony_connect_failure', '/failure')
         ->methods(['GET'])
         ->controller([OAuthController::class, 'failure']);
 };

--- a/src/Resources/config/security.php
+++ b/src/Resources/config/security.php
@@ -12,8 +12,7 @@ use SymfonyCorp\Connect\Security\Firewall\ConnectAuthenticationListener;
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('security.authentication.listener.symfony_connect')
-        ->class(ConnectAuthenticationListener::class)
+    $services->set('security.authentication.listener.symfony_connect', ConnectAuthenticationListener::class)
         ->parent('security.authentication.listener.abstract')
         ->abstract()
         ->call('setOAuthConsumer', [service('symfony_connect.oauth_consumer')])
@@ -21,41 +20,39 @@ return static function (ContainerConfigurator $container): void {
         ->call('setApi', [service('symfony_connect.api')])
         ->call('setRethrowException', [param('kernel.debug')]);
 
-    $services->set('security.authentication.provider.symfony_connect')
-        ->class(ConnectAuthenticationProvider::class)
+    $services->set('security.authentication.provider.symfony_connect', ConnectAuthenticationProvider::class)
         ->abstract()
-        ->arg(0, '')
-        ->arg(1, '');
+        ->arg(0, abstract_arg('user provider'))
+        ->arg(1, abstract_arg('firewallName / providerKey'));
 
-    $services->set('security.authentication.entry_point.symfony_connect')
-        ->class(ConnectEntryPoint::class)
+    $services->set('security.authentication.entry_point.symfony_connect', ConnectEntryPoint::class)
         ->arg(0, service('symfony_connect.oauth_consumer'))
         ->arg(1, service('security.http_utils'))
         ->arg(2, 'symfony_connect_callback');
 
-    $services->set('symfony_connect.oauth_controller')
-        ->class(OAuthController::class)
+    $services->set('security.user.provider.symfony_connect_in_memory', ConnectInMemoryUserProvider::class)
+        ->abstract();
+
+    $services->set('symfony_connect.oauth_controller', OAuthController::class)
         ->arg(0, service('security.authentication.entry_point.symfony_connect'))
-        ->arg(1, '')
-        ->arg(2, '')
+        ->arg(1, abstract_arg('start template'))
+        ->arg(2, abstract_arg('failure template'))
         ->tag('controller.service_arguments');
 
     $services->alias(OAuthController::class, 'symfony_connect.oauth_controller')
         ->public();
 
-    $services->set('symfony_connect.authenticator')
-        ->class(ConnectAuthenticator::class)
+    $services->set('symfony_connect.authenticator', ConnectAuthenticator::class)
         ->arg(0, service('symfony_connect.oauth_consumer'))
         ->arg(1, service('symfony_connect.api'))
-        ->arg(2, '')
+        ->arg(2, abstract_arg('user provider'))
         ->arg(3, service('security.http_utils'))
         ->arg(4, service('logger'))
-        ->arg(5, '')
-        ->arg(6, '')
+        ->arg(5, abstract_arg('start template'))
+        ->arg(6, abstract_arg('failure template'))
         ->call('setRethrowException', [param('kernel.debug')]);
 
-    $services->set('symfony_connect.login_success_listener')
-        ->class(LoginSuccessEventListener::class)
+    $services->set('symfony_connect.login_success_listener', LoginSuccessEventListener::class)
         ->arg(0, service('Doctrine\ORM\EntityManagerInterface')->nullOnInvalid())
         ->tag('kernel.event_subscriber');
 };


### PR DESCRIPTION
After updating a Symfony app to 8.2.0 version of this package, some tests started to fail. It's because of a minor error in the `symfony_connect_failure` route name introduced in #140.

I also updated the other config files to use abstract arguments to keep the original XML comments.